### PR TITLE
Use redis.BaseCmdable interface instead of *redis.Client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,8 @@ lint:
 		--enable=golint \
 		--enable=gofmt \
 		--enable=misspell \
-		--enable=vet ./...
+		--enable=vet ./... \
+		--deadline=60s
 .PHONY: lint
 
 # Run tests

--- a/bolt.go
+++ b/bolt.go
@@ -35,7 +35,7 @@ type (
 	// BoltContent it's a structure of cached value
 	BoltContent struct {
 		Duration int64  `json:"duration"`
-		Data     string `json:"data, omitempty"`
+		Data     string `json:"data,omitempty"`
 	}
 )
 

--- a/file.go
+++ b/file.go
@@ -20,7 +20,7 @@ type (
 	// FileContent it's a structure of cached value
 	FileContent struct {
 		Duration int64  `json:"duration"`
-		Data     string `json:"data, omitempty"`
+		Data     string `json:"data,omitempty"`
 	}
 )
 

--- a/redis.go
+++ b/redis.go
@@ -8,12 +8,12 @@ import (
 type (
 	// Redis it's a wrap around the redis driver
 	Redis struct {
-		driver *redis.Client
+		driver redis.BaseCmdable
 	}
 )
 
 // NewRedis creates an instance of Redis cache driver
-func NewRedis(driver *redis.Client) *Redis {
+func NewRedis(driver redis.BaseCmdable) *Redis {
 	return &Redis{driver}
 }
 


### PR DESCRIPTION
This allows to use redis.ClusterClient in addition to the redis.Client.