### PR TITLE
Deprecate golang versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,10 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - '1.15.x'
-          - '1.16.x'
           - '1.17.x'
+          - '1.18.x'
+          - '1.19.x'
+          - '1.20.x'
         platform: [ubuntu-latest]
 
     name: test
@@ -38,24 +39,26 @@ jobs:
 
     steps:
       - name: checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: setup go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
 
-      - name: install golanci-linter
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.43.0
+      - name: unshallow
+        run: git fetch --prune --unshallow
+
+      - name: golanci-linter
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.51.2
 
       - name: run unit tests
         run: make test
 
-      - name: run linter
-        run: make lint
-
       - name: upload code coverage
-        uses: codecov/codecov-action@v2.0.2
+        uses: codecov/codecov-action@v3.1.1
         if: contains(github.ref, 'master')
         with:
           file: ./cover.out

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -6,10 +6,9 @@ format = "colored-line-number"
 
 [linters]
 enable = [
-    "gocyclo", "unconvert", "goimports", "unused", "varcheck", "vetshadow",
-    "misspell", "nakedret", "errcheck", "revive", "ineffassign", "deadcode",
-    "goconst", "vet", "unparam", "gofumpt", "prealloc", "gomnd", "gocritic"
-]
+    "gocyclo", "unconvert", "goimports", "unused", "vetshadow","misspell",
+    "nakedret", "errcheck", "revive", "ineffassign", "goconst", "vet",
+    "unparam", "gofumpt", "prealloc", "gomnd", "gocritic"]
 
 [issues]
 exclude-use-default = false

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # Clean up
 clean:
-	@rm -fR ./cover*
+	@rm -fR ./vendor/ ./cover.*
 .PHONY: clean
 
 # Run tests and generates html coverage file

--- a/bolt/bolt.go
+++ b/bolt/bolt.go
@@ -1,3 +1,4 @@
+// Package bolt providers a cache driver that stores the cache using BoltDB.
 package bolt
 
 import (

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -1,3 +1,5 @@
+// Package chain provides chaining cache drivers operations, in case of failure
+// the driver try to apply using the next driver informed, until fail.
 package chain
 
 import (

--- a/doc.go
+++ b/doc.go
@@ -1,22 +1,23 @@
 // Package cachego provides a simple way to use cache drivers.
 //
-// Example Usage
+// # Example Usage
 //
 // The following is a simple example using memcached driver:
-//    import (
-//      "fmt"
-//      "github.com/faabiosr/cachego"
-//      "github.com/bradfitz/gomemcache/memcache"
-//    )
 //
-//    func main() {
+//	import (
+//	  "fmt"
+//	  "github.com/faabiosr/cachego"
+//	  "github.com/bradfitz/gomemcache/memcache"
+//	)
 //
-//      cache := cachego.NewMemcached(
-//          memcached.New("localhost:11211"),
-//      )
+//	func main() {
 //
-//      cache.Save("foo", "bar")
+//	  cache := cachego.NewMemcached(
+//	      memcached.New("localhost:11211"),
+//	  )
 //
-//      fmt.Println(cache.Fetch("foo"))
-//    }
+//	  cache.Save("foo", "bar")
+//
+//	  fmt.Println(cache.Fetch("foo"))
+//	}
 package cachego

--- a/file/file.go
+++ b/file/file.go
@@ -1,3 +1,4 @@
+// Package file providers a cache driver that stores the cache content in files.
 package file
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,34 @@
 module github.com/faabiosr/cachego
 
-go 1.15
+go 1.17
 
 require (
 	github.com/bradfitz/gomemcache v0.0.0-20170208213004-1952afaa557d
-	github.com/garyburd/redigo v1.6.0 // indirect
 	github.com/mattn/go-sqlite3 v1.6.0
-	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
-	github.com/onsi/ginkgo v1.13.0 // indirect
 	go.etcd.io/bbolt v1.3.4
 	go.mongodb.org/mongo-driver v1.9.0
-	gopkg.in/bsm/ratelimit.v1 v1.0.0-20160220154919-db14e161995a // indirect
-	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/mgo.v2 v2.0.0-20160818020120-3f83fa500528
 	gopkg.in/redis.v4 v4.2.4
+)
+
+require (
+	github.com/garyburd/redigo v1.6.0 // indirect
+	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/golang/snappy v0.0.1 // indirect
+	github.com/klauspost/compress v1.13.6 // indirect
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/onsi/ginkgo v1.13.0 // indirect
+	github.com/onsi/gomega v1.10.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
+	github.com/xdg-go/scram v1.0.2 // indirect
+	github.com/xdg-go/stringprep v1.0.2 // indirect
+	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
+	golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f // indirect
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
+	golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 // indirect
+	golang.org/x/text v0.3.5 // indirect
+	gopkg.in/bsm/ratelimit.v1 v1.0.0-20160220154919-db14e161995a // indirect
+	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
+	gopkg.in/yaml.v2 v2.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -16,7 +16,6 @@ github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:x
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
-github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -104,7 +103,6 @@ google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
-google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 gopkg.in/bsm/ratelimit.v1 v1.0.0-20160220154919-db14e161995a h1:stTHdEoWg1pQ8riaP5ROrjS6zy6wewH/Q2iwnLCQUXY=
 gopkg.in/bsm/ratelimit.v1 v1.0.0-20160220154919-db14e161995a/go.mod h1:KF9sEfUPAXdG8Oev9e99iLGnl2uJMjc5B+4y3O7x610=

--- a/memcached/memcached.go
+++ b/memcached/memcached.go
@@ -1,3 +1,4 @@
+// Package memcached providers a cache driver that stores the cache in Memcached.
 package memcached
 
 import (

--- a/mongo/mgo.go
+++ b/mongo/mgo.go
@@ -1,3 +1,4 @@
+// Package mongo providers a cache driver that uses MongoDB with MGO driver.
 package mongo
 
 import (

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -1,3 +1,4 @@
+// Package redis providers a cache driver that stores the cache in Redis.
 package redis
 
 import (

--- a/sqlite3/sqlite3.go
+++ b/sqlite3/sqlite3.go
@@ -1,3 +1,4 @@
+// Package sqlite3 providers a cache driver that stores the cache in SQLite3.
 package sqlite3
 
 import (

--- a/sync/map.go
+++ b/sync/map.go
@@ -1,3 +1,4 @@
+// Package sync providers a cache driver that uses standard golang sync.Map.
 package sync
 
 import (


### PR DESCRIPTION
Deprecate support for Golang version 1.15 and 1.16, and improve the package documentation.