### PR TITLE
fix: return cachego.ErrCacheExpired

### DIFF
--- a/bolt/bolt.go
+++ b/bolt/bolt.go
@@ -55,7 +55,7 @@ func (b *bolt) read(key string) (*boltContent, error) {
 
 	if content.Duration <= time.Now().Unix() {
 		_ = b.Delete(key)
-		return nil, errors.New("cache expired")
+		return nil, cachego.ErrCacheExpired
 	}
 
 	return content, nil

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -3,7 +3,6 @@ package mongo
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/faabiosr/cachego"
@@ -50,7 +49,7 @@ func (m *mongoCache) Fetch(key string) (string, error) {
 	content := &mongoContent{}
 	result := m.collection.FindOne(context.TODO(), bson.M{"_id": bson.M{"$eq": key}})
 	if result == nil {
-		return "", errors.New("cache expired")
+		return "", cachego.ErrCacheExpired
 	}
 	if result.Err() != nil {
 		return "", result.Err()
@@ -66,7 +65,7 @@ func (m *mongoCache) Fetch(key string) (string, error) {
 
 	if content.Duration <= time.Now().Unix() {
 		_ = m.Delete(key)
-		return "", errors.New("cache expired")
+		return "", cachego.ErrCacheExpired
 	}
 	return content.Value, nil
 }

--- a/sqlite3/sqlite3.go
+++ b/sqlite3/sqlite3.go
@@ -3,7 +3,6 @@ package sqlite3
 
 import (
 	"database/sql"
-	"errors"
 	"fmt"
 	"time"
 
@@ -93,7 +92,7 @@ func (s *sqlite3) Fetch(key string) (string, error) {
 
 	if lifetime <= time.Now().Unix() {
 		_ = s.Delete(key)
-		return "", errors.New("cache expired")
+		return "", cachego.ErrCacheExpired
 	}
 
 	return value, nil


### PR DESCRIPTION
## what

I think return cachego.ErrCacheExpired when kv is expired，The business layer only needs to judge that the returned error is `cachego.ErrCacheExpired`.

```go
res, err := cache.Fetch(key)
if err == cachego.ErrCacheExpired {
        value := dao.Select(key)
        cache.Save(key, value, 10 * time.Hour)
}
...
```